### PR TITLE
feat: native LNS softmax using xlns_div and xlns primitives

### DIFF
--- a/xlns16.cpp
+++ b/xlns16.cpp
@@ -595,6 +595,18 @@ inline xlns16 xlns16_pow(xlns16 base, xlns16 exponent) {
     return fp2xlns16(powf(fbase, fexp));
 }
 
+
+// Full softmax: exp(a[i]-max) / sum(exp(a[j]-max)), using LNS primitives
+inline void xlns16_softmax(const xlns16 *a, xlns16 *c, size_t n) {
+    if (n == 0) return;
+    xlns16 maxval = xlns16_max_array(a, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_exp(xlns16_sub(a[i], maxval));
+    xlns16 total = xlns16_sum(c, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_div(c[i], total);
+}
+
 /*END OF PORTABLE CODE THAT DEPENDS ON <math.h>*/
 
 

--- a/xlns32.cpp
+++ b/xlns32.cpp
@@ -633,6 +633,18 @@ inline xlns32 xlns32_pow(xlns32 base, xlns32 exponent) {
 }
 
 
+
+// Full softmax: exp(a[i]-max) / sum(exp(a[j]-max)), using LNS primitives
+inline void xlns32_softmax(const xlns32 *a, xlns32 *c, size_t n) {
+    if (n == 0) return;
+    xlns32 maxval = xlns32_max_array(a, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns32_exp(xlns32_sub(a[i], maxval));
+    xlns32 total = xlns32_sum(c, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns32_div(c[i], total);
+}
+
 /*END OF PORTABLE CODE THAT DEPENDS ON <math.h>*/
 
 


### PR DESCRIPTION
## Summary
Implements a complete, normalized Softmax function natively in the LNS domain.

## Changes
Added `xlns32_softmax` and `xlns16_softmax`. Instead of converting elements to `float` for computation, these use native LNS primitives:
- `xlns_sub` for numerical stability (subtracting max)
- `xlns_sum` to accumulate the total in the log domain
- `xlns_div` to normalize the probabilities 

This provides a mathematically complete Softmax (probabilities sum to 1.0) while keeping the arithmetic natively in the Logarithmic Number System. The existing `softmax_exp` helper is preserved unchanged. 
