### PR TITLE
Fix subnormal float conversion in fp2xlns16 and fp2xlns32

### DIFF
--- a/xlns16.cpp
+++ b/xlns16.cpp
@@ -25,6 +25,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <cfloat>  // For FLT_MIN
   //typedef unsigned short xlns16;
   //typedef signed short xlns16_signed;
   #ifdef _WIN32
@@ -265,8 +266,14 @@ inline float xlns162fp(xlns16 x)
 
 xlns16 fp2xlns16(float x)
 {
-	if (x==0.0)
+	// Handle exact zero
+	if (x == 0.0f)
 		return(xlns16_zero);
+	
+	// Handle subnormal numbers - convert to zero
+	if (fabsf(x) < FLT_MIN)
+		return(xlns16_zero);
+	
 	else if (x > 0.0)
 		return xlns16_abs((xlns16_signed) ((log(x)/log(2.0))*xlns16_scale))
 		       ^xlns16_logsignmask;

--- a/xlns32.cpp
+++ b/xlns32.cpp
@@ -21,6 +21,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <cfloat>  // For FLT_MIN
 
 // choose long (for 16-bit arch) or int (for 32- or 64-bit arch)
 //   perhaps the following might work in either case:
@@ -291,8 +292,14 @@ xlns32 xlns32_add(xlns32 x, xlns32 y)
 
 xlns32 fp2xlns32(float x)
 {
-	if (x==0.0)
+	// Handle exact zero
+	if (x == 0.0f)
 		return(xlns32_zero);
+	
+	// Handle subnormal numbers - convert to zero
+	if (fabsf(x) < FLT_MIN)
+		return(xlns32_zero);
+	
 	else if (x > 0.0)
 		return xlns32_abs((xlns32_signed) ((log(x)/log(2.0))*xlns32_scale))
 		       ^xlns32_logsignmask;


### PR DESCRIPTION
Handle IEEE 754 subnormal numbers by checking fabsf(x) < FLT_MIN and converting them to LNS zero representation to prevent garbage values when passed through logarithm function.