### PR TITLE
Implemented lns-native softmax, masked and non-masked implementations

### DIFF
--- a/xlns16.cpp
+++ b/xlns16.cpp
@@ -627,12 +627,47 @@ inline xlns16 xlns16_pow(xlns16 base, xlns16 exponent) {
 }
 
 
-// Full softmax: exp(a[i]-max) / sum(exp(a[j]-max)), using LNS primitives
-inline void xlns16_softmax(const xlns16 *a, xlns16 *c, size_t n) {
+// Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)).
+// a[i] == xlns16_neg_inf is treated as already-excluded and skips the scale
+// multiply (scaling the sentinel could otherwise perturb its bit pattern).
+// c may alias a (in-place): every pass only reads index i before writing
+// index i, and the sum pass runs after all per-element writes complete.
+inline void xlns16_softmax(const xlns16 *a, xlns16 *c, size_t n, xlns16 scale = xlns16_one) {
     if (n == 0) return;
-    xlns16 maxval = xlns16_max_array(a, n);
+    xlns16 maxval = xlns16_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns16 v = a[i];
+        if (v != xlns16_neg_inf) v = xlns16_mul(v, scale);
+        c[i] = v;
+        if (xlns16_gt(c[i], maxval)) maxval = c[i];
+    }
     for (size_t i = 0; i < n; i++)
-        c[i] = xlns16_exp(xlns16_sub(a[i], maxval));
+        c[i] = xlns16_exp(xlns16_sub(c[i], maxval));
+    xlns16 total = xlns16_sum(c, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_div(c[i], total);
+}
+
+// Masked variant of xlns16_softmax. mask[i] is a pre-converted xlns16 value:
+// xlns16_neg_inf marks a masked-out position (forces the output to
+// xlns16_neg_inf regardless of a[i]/scale), xlns16_zero means "no mask" for
+// that position, anything else is treated as an additive bias (e.g. ALiBi).
+inline void xlns16_softmax_masked(const xlns16 *a, const xlns16 *mask, xlns16 *c,
+                                   size_t n, xlns16 scale = xlns16_one) {
+    if (n == 0) return;
+    xlns16 maxval = xlns16_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns16 v = a[i];
+        if (v != xlns16_neg_inf) {
+            v = xlns16_mul(v, scale);
+            if (mask[i] == xlns16_neg_inf) v = xlns16_neg_inf;
+            else if (!xlns16_is_zero(mask[i])) v = xlns16_add(v, mask[i]);
+        }
+        c[i] = v;
+        if (xlns16_gt(c[i], maxval)) maxval = c[i];
+    }
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_exp(xlns16_sub(c[i], maxval));
     xlns16 total = xlns16_sum(c, n);
     for (size_t i = 0; i < n; i++)
         c[i] = xlns16_div(c[i], total);


### PR DESCRIPTION
# xlnscpp PR: scale/mask-aware `xlns16_softmax` + new `xlns16_softmax_masked`

## Summary

Extend `xlns16_softmax` with an optional `scale` argument (defaulted to
`xlns16_one`, so existing 3-arg call sites keep compiling) and add a new
`xlns16_softmax_masked` that additionally applies a per-element additive mask:

```cpp
inline void xlns16_softmax(const xlns16 *a, xlns16 *c, size_t n, xlns16 scale = xlns16_one);
inline void xlns16_softmax_masked(const xlns16 *a, const xlns16 *mask, xlns16 *c,
                                   size_t n, xlns16 scale = xlns16_one);
```

Both treat `a[i] == xlns16_neg_inf` as already-excluded (skip the scale
multiply, since scaling the sentinel could otherwise perturb its bit
pattern). `xlns16_softmax_masked` additionally treats `mask[i] ==
xlns16_neg_inf` as forcing that output to `xlns16_neg_inf` regardless of
`a[i]`/`scale`, and skips the add when `mask[i]` is `xlns16_zero`.

## Motivation

The previous `xlns16_softmax(a, c, n)` had no way to apply the
`scale * x + mask` step that attention-style softmax needs (of the form
`softmax(QK^T / sqrt(d) + causal_mask)`).
This PR moves that logic into xlnscpp so it can be reused
directly.


## Test plan

Covers: plain softmax vs. a float reference, a dense-grid sweep of the plain
(unmasked, unscaled) path (one logit swept over `[-12, 12]` in steps of `0.01`
against a fixed background vector, tracking max absolute and relative error
across ~14k samples), the `scale` path (attention-style `1/sqrt(d)`), the
masked path (masked slots collapse to ~0 probability), a pre-masked-logit case
(`a[i] == xlns16_neg_inf`).

```
plain softmax max abs diff vs float ref: 0.003188
dense grid plain softmax (n_samples=14406, vector size 6):
  max absolute error: 0.006531
  max relative error (ref>0.05): 3.0722%
scaled softmax max abs diff vs float ref: 0.000652
masked softmax max abs diff vs float ref: 0.002802
All checks passed.
```

## Notes

- `scale` defaults to `xlns16_one` so `xlnscpp`'s own `tests/xlns16_explog_test.cpp`
  and `test16lpvip32monte.cpp`, which call the 3-arg form, keep compiling
  unchanged. (Can modify these tests as required)
- The ggml-side consumer (`lns_soft_max` in the LNS ggml backend) now only
  extracts rows/mask from the `ggml_tensor` and delegates the actual softmax
  math to these two functions; updated in xlns-16-toy-impl.
- The `<= -3e38f` "masked" float sentinel used by ggml's `SOFT_MAX` mask
  tensor is a ggml convention, not an xlns16 concept, so that conversion
  stays in the lns-ops.cpp file, and `mask[i]` here is always an already-converted
  `xlns16` value (`xlns16_neg_inf` or an additive bias).
