### PR TITLE
Align `xlns32_softmax` with xlns16 (scale + masked)

### DIFF
--- a/xlns32.cpp
+++ b/xlns32.cpp
@@ -642,12 +642,47 @@ inline xlns32 xlns32_pow(xlns32 base, xlns32 exponent) {
 
 
 
-// Full softmax: exp(a[i]-max) / sum(exp(a[j]-max)), using LNS primitives
-inline void xlns32_softmax(const xlns32 *a, xlns32 *c, size_t n) {
+// Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)).
+// a[i] == xlns32_neg_inf is treated as already-excluded and skips the scale
+// multiply (scaling the sentinel could otherwise perturb its bit pattern).
+// c may alias a (in-place): every pass only reads index i before writing
+// index i, and the sum pass runs after all per-element writes complete.
+inline void xlns32_softmax(const xlns32 *a, xlns32 *c, size_t n, xlns32 scale = xlns32_one) {
     if (n == 0) return;
-    xlns32 maxval = xlns32_max_array(a, n);
+    xlns32 maxval = xlns32_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns32 v = a[i];
+        if (v != xlns32_neg_inf) v = xlns32_mul(v, scale);
+        c[i] = v;
+        if (xlns32_gt(c[i], maxval)) maxval = c[i];
+    }
     for (size_t i = 0; i < n; i++)
-        c[i] = xlns32_exp(xlns32_sub(a[i], maxval));
+        c[i] = xlns32_exp(xlns32_sub(c[i], maxval));
+    xlns32 total = xlns32_sum(c, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns32_div(c[i], total);
+}
+
+// Masked variant of xlns32_softmax. mask[i] is a pre-converted xlns32 value:
+// xlns32_neg_inf marks a masked-out position (forces the output to
+// xlns32_neg_inf regardless of a[i]/scale), xlns32_zero means "no mask" for
+// that position, anything else is treated as an additive bias (e.g. ALiBi).
+inline void xlns32_softmax_masked(const xlns32 *a, const xlns32 *mask, xlns32 *c,
+                                   size_t n, xlns32 scale = xlns32_one) {
+    if (n == 0) return;
+    xlns32 maxval = xlns32_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns32 v = a[i];
+        if (v != xlns32_neg_inf) {
+            v = xlns32_mul(v, scale);
+            if (mask[i] == xlns32_neg_inf) v = xlns32_neg_inf;
+            else if (!xlns32_is_zero(mask[i])) v = xlns32_add(v, mask[i]);
+        }
+        c[i] = v;
+        if (xlns32_gt(c[i], maxval)) maxval = c[i];
+    }
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns32_exp(xlns32_sub(c[i], maxval));
     xlns32 total = xlns32_sum(c, n);
     for (size_t i = 0; i < n; i++)
         c[i] = xlns32_div(c[i], total);


### PR DESCRIPTION
# xlnscpp PR: Align `xlns32_softmax` with xlns16 (scale + masked)

## Summary

Bring `xlns32` softmax in line with the xlns16 implementation. Extend `xlns32_softmax` with an optional `scale` (default `xlns32_one`), and add `xlns32_softmax_masked`:

```
softmax(a, scale)        = exp(scale*a[i] - max) / sum_j exp(scale*a[j] - max)
softmax_masked(a, mask)  = same, after applying mask to scaled logits
```

Mask semantics match xlns16: `xlns32_neg_inf` hard-excludes a position, `xlns32_zero` is a no-op, and any other value is an additive bias (e.g. ALiBi). Both functions skip scaling when `a[i]` is already `neg_inf` so the sentinel bit pattern is preserved. `c` may alias `a` (in-place).

## Motivation

xlns32 only had an unscaled `xlns32_softmax`. This PR mirrors the xlns16 structure while keeping xlns32’s existing style: each step (`mul` / `exp` / `sum` / `div`) may float-roundtrip internally, rather than requiring fully LNS-native math or a single bulk float softmax.

## Testing

Expected: max absolute error vs float reference below 0.02 on plain / scaled / masked spot checks; dense grid on `[-12, 12]` below 0.02 abs and 5% relative where `ref > 0.05`; masked and pre-`neg_inf` slots near zero.

```
plain softmax max abs diff vs float ref: 0.000000
dense grid plain softmax (n_samples=14406, vector size 6):
  max absolute error: 0.000000
  max relative error (ref>0.05): 0.0000%
scaled softmax (1/sqrt(64)) max abs diff: 0.000000
masked softmax max abs diff: 0.000000 (excluded slots ~0; sums to ~1)
pre-masked (xlns32_neg_inf) slot -> 0.000000
in-place plain/masked match out-of-place
```

## Notes

- Default `scale = xlns32_one` keeps existing 3-arg call sites compiling unchanged.
- `xlns32_softmax_exp` is unchanged (building block without scale/mask).