### PR TITLE
Softmax monte -- masked and non masked variants, both monte and monte_bylpvip

### DIFF
--- a/xlns16monte.cpp
+++ b/xlns16monte.cpp
@@ -86,12 +86,13 @@ inline xlns16 xlns16_vec_dot_monte(const xlns16 *a, const xlns16 *b, size_t n) {
 }
 
 
-// Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)), MCLNS adds.
+// Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)).
+// Same control flow as xlns16_softmax; only the normalization sum uses MCLNS
+// (xlns16_sum_monte).
 // a[i] == xlns16_neg_inf is treated as already-excluded and skips the scale
 // multiply (scaling the sentinel could otherwise perturb its bit pattern).
 // c may alias a (in-place): every pass only reads index i before writing
 // index i, and the sum pass runs after all per-element writes complete.
-// Monte is used for every add: mask bias, max-subtraction, and the sum.
 inline void xlns16_softmax_monte(const xlns16 *a, xlns16 *c, size_t n,
                                   xlns16 scale = xlns16_one) {
     if (n == 0) return;
@@ -103,13 +104,14 @@ inline void xlns16_softmax_monte(const xlns16 *a, xlns16 *c, size_t n,
         if (xlns16_gt(c[i], maxval)) maxval = c[i];
     }
     for (size_t i = 0; i < n; i++)
-        c[i] = xlns16_exp(xlns16_add_monte(c[i], xlns16_signmask ^ maxval));
+        c[i] = xlns16_exp(xlns16_sub(c[i], maxval));
     xlns16 total = xlns16_sum_monte(c, n);
     for (size_t i = 0; i < n; i++)
         c[i] = xlns16_div(c[i], total);
 }
 
-// Masked variant of xlns16_softmax_monte. mask[i] is a pre-converted xlns16 value:
+// Masked variant of xlns16_softmax_monte (same as xlns16_softmax_masked, with
+// xlns16_sum_monte for normalization). mask[i] is a pre-converted xlns16 value:
 // xlns16_neg_inf marks a masked-out position (forces the output to
 // xlns16_neg_inf regardless of a[i]/scale), xlns16_zero means "no mask" for
 // that position, anything else is treated as an additive bias (e.g. ALiBi).
@@ -122,13 +124,13 @@ inline void xlns16_softmax_masked_monte(const xlns16 *a, const xlns16 *mask, xln
         if (v != xlns16_neg_inf) {
             v = xlns16_mul(v, scale);
             if (mask[i] == xlns16_neg_inf) v = xlns16_neg_inf;
-            else if (!xlns16_is_zero(mask[i])) v = xlns16_add_monte(v, mask[i]);
+            else if (!xlns16_is_zero(mask[i])) v = xlns16_add(v, mask[i]);
         }
         c[i] = v;
         if (xlns16_gt(c[i], maxval)) maxval = c[i];
     }
     for (size_t i = 0; i < n; i++)
-        c[i] = xlns16_exp(xlns16_add_monte(c[i], xlns16_signmask ^ maxval));
+        c[i] = xlns16_exp(xlns16_sub(c[i], maxval));
     xlns16 total = xlns16_sum_monte(c, n);
     for (size_t i = 0; i < n; i++)
         c[i] = xlns16_div(c[i], total);

--- a/xlns16monte.cpp
+++ b/xlns16monte.cpp
@@ -86,12 +86,49 @@ inline xlns16 xlns16_vec_dot_monte(const xlns16 *a, const xlns16 *b, size_t n) {
 }
 
 
-// Full softmax: exp(a[i]-max) / sum(exp(a[j]-max)), using LNS primitives
-inline void xlns16_softmax_monte(const xlns16 *a, xlns16 *c, size_t n) {
+// Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)), MCLNS adds.
+// a[i] == xlns16_neg_inf is treated as already-excluded and skips the scale
+// multiply (scaling the sentinel could otherwise perturb its bit pattern).
+// c may alias a (in-place): every pass only reads index i before writing
+// index i, and the sum pass runs after all per-element writes complete.
+// Monte is used for every add: mask bias, max-subtraction, and the sum.
+inline void xlns16_softmax_monte(const xlns16 *a, xlns16 *c, size_t n,
+                                  xlns16 scale = xlns16_one) {
     if (n == 0) return;
-    xlns16 maxval = xlns16_max_array(a, n);
+    xlns16 maxval = xlns16_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns16 v = a[i];
+        if (v != xlns16_neg_inf) v = xlns16_mul(v, scale);
+        c[i] = v;
+        if (xlns16_gt(c[i], maxval)) maxval = c[i];
+    }
     for (size_t i = 0; i < n; i++)
-        c[i] = xlns16_exp(xlns16_add_monte(a[i], xlns16_signmask^maxval));
+        c[i] = xlns16_exp(xlns16_add_monte(c[i], xlns16_signmask ^ maxval));
+    xlns16 total = xlns16_sum_monte(c, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_div(c[i], total);
+}
+
+// Masked variant of xlns16_softmax_monte. mask[i] is a pre-converted xlns16 value:
+// xlns16_neg_inf marks a masked-out position (forces the output to
+// xlns16_neg_inf regardless of a[i]/scale), xlns16_zero means "no mask" for
+// that position, anything else is treated as an additive bias (e.g. ALiBi).
+inline void xlns16_softmax_masked_monte(const xlns16 *a, const xlns16 *mask, xlns16 *c,
+                                         size_t n, xlns16 scale = xlns16_one) {
+    if (n == 0) return;
+    xlns16 maxval = xlns16_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns16 v = a[i];
+        if (v != xlns16_neg_inf) {
+            v = xlns16_mul(v, scale);
+            if (mask[i] == xlns16_neg_inf) v = xlns16_neg_inf;
+            else if (!xlns16_is_zero(mask[i])) v = xlns16_add_monte(v, mask[i]);
+        }
+        c[i] = v;
+        if (xlns16_gt(c[i], maxval)) maxval = c[i];
+    }
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_exp(xlns16_add_monte(c[i], xlns16_signmask ^ maxval));
     xlns16 total = xlns16_sum_monte(c, n);
     for (size_t i = 0; i < n; i++)
         c[i] = xlns16_div(c[i], total);

--- a/xlns16monte_bylpvip.cpp
+++ b/xlns16monte_bylpvip.cpp
@@ -56,12 +56,13 @@ inline xlns16 xlns16_vec_dot_monte(const xlns16 *a, const xlns16 *b, size_t n) {
 }
 
 
-// Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)), MCLNS adds.
+// Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)).
+// Same control flow as xlns16_softmax; only the normalization sum uses MCLNS
+// (xlns16_sum_monte).
 // a[i] == xlns16_neg_inf is treated as already-excluded and skips the scale
 // multiply (scaling the sentinel could otherwise perturb its bit pattern).
 // c may alias a (in-place): every pass only reads index i before writing
 // index i, and the sum pass runs after all per-element writes complete.
-// Monte is used for every add: mask bias, max-subtraction, and the sum.
 inline void xlns16_softmax_monte(const xlns16 *a, xlns16 *c, size_t n,
                                   xlns16 scale = xlns16_one) {
     if (n == 0) return;
@@ -73,13 +74,14 @@ inline void xlns16_softmax_monte(const xlns16 *a, xlns16 *c, size_t n,
         if (xlns16_gt(c[i], maxval)) maxval = c[i];
     }
     for (size_t i = 0; i < n; i++)
-        c[i] = xlns16_exp(xlns16_add_monte(c[i], xlns16_signmask ^ maxval));
+        c[i] = xlns16_exp(xlns16_sub(c[i], maxval));
     xlns16 total = xlns16_sum_monte(c, n);
     for (size_t i = 0; i < n; i++)
         c[i] = xlns16_div(c[i], total);
 }
 
-// Masked variant of xlns16_softmax_monte. mask[i] is a pre-converted xlns16 value:
+// Masked variant of xlns16_softmax_monte (same as xlns16_softmax_masked, with
+// xlns16_sum_monte for normalization). mask[i] is a pre-converted xlns16 value:
 // xlns16_neg_inf marks a masked-out position (forces the output to
 // xlns16_neg_inf regardless of a[i]/scale), xlns16_zero means "no mask" for
 // that position, anything else is treated as an additive bias (e.g. ALiBi).
@@ -92,13 +94,13 @@ inline void xlns16_softmax_masked_monte(const xlns16 *a, const xlns16 *mask, xln
         if (v != xlns16_neg_inf) {
             v = xlns16_mul(v, scale);
             if (mask[i] == xlns16_neg_inf) v = xlns16_neg_inf;
-            else if (!xlns16_is_zero(mask[i])) v = xlns16_add_monte(v, mask[i]);
+            else if (!xlns16_is_zero(mask[i])) v = xlns16_add(v, mask[i]);
         }
         c[i] = v;
         if (xlns16_gt(c[i], maxval)) maxval = c[i];
     }
     for (size_t i = 0; i < n; i++)
-        c[i] = xlns16_exp(xlns16_add_monte(c[i], xlns16_signmask ^ maxval));
+        c[i] = xlns16_exp(xlns16_sub(c[i], maxval));
     xlns16 total = xlns16_sum_monte(c, n);
     for (size_t i = 0; i < n; i++)
         c[i] = xlns16_div(c[i], total);

--- a/xlns16monte_bylpvip.cpp
+++ b/xlns16monte_bylpvip.cpp
@@ -56,12 +56,49 @@ inline xlns16 xlns16_vec_dot_monte(const xlns16 *a, const xlns16 *b, size_t n) {
 }
 
 
-// Full softmax: exp(a[i]-max) / sum(exp(a[j]-max)), using LNS primitives
-inline void xlns16_softmax_monte(const xlns16 *a, xlns16 *c, size_t n) {
+// Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)), MCLNS adds.
+// a[i] == xlns16_neg_inf is treated as already-excluded and skips the scale
+// multiply (scaling the sentinel could otherwise perturb its bit pattern).
+// c may alias a (in-place): every pass only reads index i before writing
+// index i, and the sum pass runs after all per-element writes complete.
+// Monte is used for every add: mask bias, max-subtraction, and the sum.
+inline void xlns16_softmax_monte(const xlns16 *a, xlns16 *c, size_t n,
+                                  xlns16 scale = xlns16_one) {
     if (n == 0) return;
-    xlns16 maxval = xlns16_max_array(a, n);
+    xlns16 maxval = xlns16_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns16 v = a[i];
+        if (v != xlns16_neg_inf) v = xlns16_mul(v, scale);
+        c[i] = v;
+        if (xlns16_gt(c[i], maxval)) maxval = c[i];
+    }
     for (size_t i = 0; i < n; i++)
-        c[i] = xlns16_exp(xlns16_add_monte(a[i], xlns16_signmask^maxval));
+        c[i] = xlns16_exp(xlns16_add_monte(c[i], xlns16_signmask ^ maxval));
+    xlns16 total = xlns16_sum_monte(c, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_div(c[i], total);
+}
+
+// Masked variant of xlns16_softmax_monte. mask[i] is a pre-converted xlns16 value:
+// xlns16_neg_inf marks a masked-out position (forces the output to
+// xlns16_neg_inf regardless of a[i]/scale), xlns16_zero means "no mask" for
+// that position, anything else is treated as an additive bias (e.g. ALiBi).
+inline void xlns16_softmax_masked_monte(const xlns16 *a, const xlns16 *mask, xlns16 *c,
+                                         size_t n, xlns16 scale = xlns16_one) {
+    if (n == 0) return;
+    xlns16 maxval = xlns16_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns16 v = a[i];
+        if (v != xlns16_neg_inf) {
+            v = xlns16_mul(v, scale);
+            if (mask[i] == xlns16_neg_inf) v = xlns16_neg_inf;
+            else if (!xlns16_is_zero(mask[i])) v = xlns16_add_monte(v, mask[i]);
+        }
+        c[i] = v;
+        if (xlns16_gt(c[i], maxval)) maxval = c[i];
+    }
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_exp(xlns16_add_monte(c[i], xlns16_signmask ^ maxval));
     xlns16 total = xlns16_sum_monte(c, n);
     for (size_t i = 0; i < n; i++)
         c[i] = xlns16_div(c[i], total);


### PR DESCRIPTION
# xlnscpp PR: Align monte softmax with xlns16 (scale + masked)

## Summary

Bring `xlns16_softmax_monte` in line with `xlns16_softmax`, and add `xlns16_softmax_masked_monte`, in both Monte backends (`xlns16monte.cpp` and `xlns16monte_bylpvip.cpp`):

```
softmax_monte(a, scale)        = exp(scale*a[i] - max) / sum_j exp(scale*a[j] - max)
softmax_masked_monte(a, mask)  = same, after applying mask to scaled logits
```

Mask semantics match xlns16: `xlns16_neg_inf` hard-excludes a position, `xlns16_zero` is a no-op, and any other value is an additive bias (e.g. ALiBi). Scaling is skipped when `a[i]` is already `neg_inf` so the sentinel bit pattern is preserved. `c` may alias `a` (in-place).

Monte (`xlns16_add_monte`) is used for every add that appears: mask bias, max-subtraction (`add_monte(c[i], signmask^maxval)`), and the normalization sum via `xlns16_sum_monte`. Both backends keep identical softmax bodies; only `xlns16_add_monte` differs (pure 16-bit MCLNS vs same-noise + `xlns32_add_lpvip`).

## Motivation

Monte softmax previously lacked `scale` and a masked variant.

## Testing

Pure monte (`xlns16_alt` + `xlns16_table`; needs non-ideal path for `monte_modifier`):

```
plain softmax max abs diff vs float ref: 0.003188
dense grid plain softmax (n_samples=2886, vector size 6):
  max absolute error: 0.006146
  max relative error (ref>0.05): 2.4851%
scaled softmax (1/sqrt(64)) max abs diff: 0.000652
masked softmax max abs diff: 0.002802 (excluded slots ~0; sums to ~1)
```

bylpvip backend (`xlns16_ideal` + `xlns32lpvip`): similar spot/grid margins.

## Notes

- Default `scale = xlns16_one` keeps existing 3-arg call sites compiling unchanged.

