### PR TITLE
Implemented lpvip masked and non-masked softmax

### DIFF
--- a/xlns32lpvip.cpp
+++ b/xlns32lpvip.cpp
@@ -62,7 +62,7 @@ inline xlns32 xlns32_add_lpvip(xlns32 x, xlns32 y)
 // Sum of array elements: result = Σ a[i]
 inline xlns16 xlns16_sum_lpvip32(const xlns16 *a, size_t n) {
     if (n == 0) return xlns16_zero;
-    xlns32 sum = a[0];
+    xlns32 sum = ((xlns32)a[0])<<16;
     for (size_t i = 1; i < n; i++) {
         sum = xlns32_add_lpvip(sum, ((xlns32)a[i])<<16);
     }
@@ -100,6 +100,53 @@ inline void xlns16_layernorm_lpvip32(const xlns16 *x, xlns16 *out,
         if (gamma) out[i] = xlns16_mul(out[i], gamma[i]);
         if (beta)  out[i] = xlns16_add(out[i], beta[i]);
     }
+}
+
+// Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)).
+// Same control flow as xlns16_softmax. Scale, mask bias, and max-sub use
+// plain xlns16 ops; only the normalization sum uses xlns16_sum_lpvip32.
+// a[i] == xlns16_neg_inf is treated as already-excluded and skips the scale
+// multiply. c may alias a (in-place).
+inline void xlns16_softmax_lpvip32(const xlns16 *a, xlns16 *c, size_t n,
+                                    xlns16 scale = xlns16_one) {
+    if (n == 0) return;
+    xlns16 maxval = xlns16_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns16 v = a[i];
+        if (v != xlns16_neg_inf) v = xlns16_mul(v, scale);
+        c[i] = v;
+        if (xlns16_gt(c[i], maxval)) maxval = c[i];
+    }
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_exp(xlns16_sub(c[i], maxval));
+    xlns16 total = xlns16_sum_lpvip32(c, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_div(c[i], total);
+}
+
+// Masked variant of xlns16_softmax_lpvip32. mask[i] is a pre-converted xlns16
+// value: xlns16_neg_inf marks a masked-out position, xlns16_zero means "no
+// mask", anything else is an additive bias (e.g. ALiBi).
+inline void xlns16_softmax_masked_lpvip32(const xlns16 *a, const xlns16 *mask,
+                                           xlns16 *c, size_t n,
+                                           xlns16 scale = xlns16_one) {
+    if (n == 0) return;
+    xlns16 maxval = xlns16_neg_inf;
+    for (size_t i = 0; i < n; i++) {
+        xlns16 v = a[i];
+        if (v != xlns16_neg_inf) {
+            v = xlns16_mul(v, scale);
+            if (mask[i] == xlns16_neg_inf) v = xlns16_neg_inf;
+            else if (!xlns16_is_zero(mask[i])) v = xlns16_add(v, mask[i]);
+        }
+        c[i] = v;
+        if (xlns16_gt(c[i], maxval)) maxval = c[i];
+    }
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_exp(xlns16_sub(c[i], maxval));
+    xlns16 total = xlns16_sum_lpvip32(c, n);
+    for (size_t i = 0; i < n; i++)
+        c[i] = xlns16_div(c[i], total);
 }
 
 


### PR DESCRIPTION
# xlnscpp PR: Add LPVIP32 softmax (scale + masked)

## Summary

Add `xlns16_softmax_lpvip32` and `xlns16_softmax_masked_lpvip32` in `xlns32lpvip.cpp`, aligned with `xlns16_softmax` / `xlns16_softmax_masked`:

```
softmax_lpvip32(a, scale)        = exp(scale*a[i] - max) / sum_j exp(scale*a[j] - max)
softmax_masked_lpvip32(a, mask)  = same, after applying mask to scaled logits
```

Mask semantics match xlns16.

Only the normalization sum uses LPVIP (`xlns16_sum_lpvip32`). Scale, mask bias, and max-subtraction use plain `xlns16_mul` / `xlns16_add` / `xlns16_sub` / `xlns16_exp` / `xlns16_div` — same as xlns16 — so short-vector accuracy stays close to the baseline while long sums still benefit from 32-bit LPVIP accumulation.

Also fixes `xlns16_sum_lpvip32` to initialize the accumulator as `((xlns32)a[0])<<16` (matching `vec_dot_lpvip32`); the previous unshifted start corrupted sums when element 0 dominated.

## Motivation

`summation16bit.MD` and `test16lpvip32monte.cpp` already reference `xlns16_softmax_lpvip32`, but it was unimplemented. Softmax on long vectors benefits from LPVIP summation the same way sum / dot / layernorm do. Routing max-sub through LPVIP was tried and hurt short-vector accuracy; keeping plain xlns16 for those ops matches the original “LPVIP for summation” intent.

## Testing

Compared vs float reference:

Ideal (`xlns16_ideal`):

```
plain softmax max abs diff vs float ref: 0.004406
dense grid (n_samples=14406, vector size 6):
  max abs 0.013552  max rel (ref>0.05) 2.8915%
scaled softmax (1/sqrt(64)) max abs diff: 0.002968
masked softmax max abs diff: 0.002802
```

Table + alt (`xlns16_table` + `xlns16_alt`): similar margins (dense grid vs float abs 0.012319 / rel 3.0010%).

## Notes

- Default `scale = xlns16_one` keeps existing 3-arg call sites (e.g. `test16lpvip32monte.cpp`) compiling unchanged.
