### PR TITLE
Implemented xlns16 RMS Norm

### DIFF
--- a/xlns16.cpp
+++ b/xlns16.cpp
@@ -674,6 +674,22 @@ inline void xlns16_softmax_masked(const xlns16 *a, const xlns16 *mask, xlns16 *c
 }
 
 
+// RMSNorm: dst[i] = x[i] / sqrt(mean(x^2) + eps).
+// Fully LNS-native (uses xlns16_sqrt / xlns16_recip; unlike xlns16_layernorm,
+// which takes inv_std through float). dst may alias x (in-place): the sum-of-
+// squares pass completes before any writes; the scale pass only reads index i
+// before writing index i.
+inline void xlns16_rms_norm(const xlns16 *x, xlns16 *dst, size_t n, xlns16 eps) {
+    if (n == 0) return;
+    xlns16 sum_sq = xlns16_zero;
+    for (size_t i = 0; i < n; i++)
+        sum_sq = xlns16_add(sum_sq, xlns16_square(x[i]));
+    xlns16 mean = xlns16_mul(sum_sq, fp2xlns16(1.0f / (float)n));
+    xlns16 inv_rms = xlns16_recip(xlns16_sqrt(xlns16_add(mean, eps)));
+    for (size_t i = 0; i < n; i++)
+        dst[i] = xlns16_mul(x[i], inv_rms);
+}
+
 // Layer normalization: (x - mean) / sqrt(var + eps) * gamma + beta
 inline void xlns16_layernorm(const xlns16 *x, xlns16 *out,
                        const xlns16 *gamma, const xlns16 *beta,


### PR DESCRIPTION
# xlnscpp PR: LNS-native `xlns16_rms_norm`

## Summary

Add `xlns16_rms_norm` that computes

```text
dst[i] = x[i] / sqrt(mean(x^2) + eps)
```

entirely with LNS primitives:

```cpp
inline void xlns16_rms_norm(const xlns16 *x, xlns16 *dst, size_t n, xlns16 eps);
```

## Motivation

Following the style of softmax, we move RMS Norm into xlnscpp as a reusable composite, considering the possibility that we may want to modify the summation method used.

## Testing

Covers: a fixed vector vs float reference, a dense grid sweeping one element
over `[-8, 8]` in steps of `0.01` against a fixed background, near-zero inputs
with `eps`, in-place vs out-of-place equality, and `n == 0`.

```
fixed vector max abs diff: 0.004917
fixed vector max rel diff (|ref|>0.05): 0.4085%
dense grid (n_samples=9606, vector size 6):
  max absolute error: 0.015558
  max relative error (|ref|>0.05): 1.0143%
near-zero + eps max abs diff: 0.000000
```