### PR TITLE
Implemented RMS Norm in xlns32

### DIFF
--- a/xlns32.cpp
+++ b/xlns32.cpp
@@ -689,6 +689,18 @@ inline void xlns32_softmax_masked(const xlns32 *a, const xlns32 *mask, xlns32 *c
 }
 
 
+// RMSNorm: dst[i] = x[i] / sqrt(mean(x^2) + eps).
+inline void xlns32_rms_norm(const xlns32 *x, xlns32 *dst, size_t n, xlns32 eps) {
+    if (n == 0) return;
+    xlns32 sum_sq = xlns32_zero;
+    for (size_t i = 0; i < n; i++)
+        sum_sq = xlns32_add(sum_sq, xlns32_square(x[i]));
+    xlns32 mean = xlns32_mul(sum_sq, fp2xlns32(1.0f / (float)n));
+    xlns32 inv_rms = xlns32_recip(xlns32_sqrt(xlns32_add(mean, eps)));
+    for (size_t i = 0; i < n; i++)
+        dst[i] = xlns32_mul(x[i], inv_rms);
+}
+
 // Layer normalization: (x - mean) / sqrt(var + eps) * gamma + beta
 inline void xlns32_layernorm(const xlns32 *x, xlns32 *out,
                        const xlns32 *gamma, const xlns32 *beta,


### PR DESCRIPTION
# xlnscpp PR: Add LNS-native `xlns32_rms_norm`

## Summary

Add `xlns32_rms_norm`, mirroring the xlns16 implementation:

```
rms_norm(x, eps)  = x[i] / sqrt(mean(x^2) + eps)
```

Fully LNS-native (`xlns32_square` / `add` / `mul` / `sqrt` / `recip`), unlike `xlns32_layernorm`, which takes `inv_std` through float. 

## Motivation

Brings xlns32 to parity with the xlns16 control flow, parameters, and structure.

## Testing

```
fixed vector max abs diff: 0.000000
fixed vector max rel diff (|ref|>0.05): 0.0000%
dense grid (n_samples=9606, vector size 6):
  max absolute error: 0.000001
  max relative error (|ref|>0.05): 0.0000%
near-zero + eps max abs diff: 0.000000
n==0 leaves buffer untouched
```