### PR TITLE
Implemented monte RMS Norm

### DIFF
--- a/xlns16monte.cpp
+++ b/xlns16monte.cpp
@@ -136,6 +136,19 @@ inline void xlns16_softmax_masked_monte(const xlns16 *a, const xlns16 *mask, xln
         c[i] = xlns16_div(c[i], total);
 }
 
+// RMSNorm: dst[i] = x[i] / sqrt(mean(x^2) + eps).
+// only the sum-of-squares
+// reduction uses MCLNS (xlns16_add_monte).
+inline void xlns16_rms_norm_monte(const xlns16 *x, xlns16 *dst, size_t n, xlns16 eps) {
+    if (n == 0) return;
+    xlns16 sum_sq = xlns16_zero;
+    for (size_t i = 0; i < n; i++)
+        sum_sq = xlns16_add_monte(sum_sq, xlns16_square(x[i]));
+    xlns16 mean = xlns16_mul(sum_sq, fp2xlns16(1.0f / (float)n));
+    xlns16 inv_rms = xlns16_recip(xlns16_sqrt(xlns16_add(mean, eps)));
+    for (size_t i = 0; i < n; i++)
+        dst[i] = xlns16_mul(x[i], inv_rms);
+}
 
 // Layer normalization: (x - mean) / sqrt(var + eps) * gamma + beta
 inline void xlns16_layernorm_monte(const xlns16 *x, xlns16 *out,

--- a/xlns16monte_bylpvip.cpp
+++ b/xlns16monte_bylpvip.cpp
@@ -106,6 +106,20 @@ inline void xlns16_softmax_masked_monte(const xlns16 *a, const xlns16 *mask, xln
         c[i] = xlns16_div(c[i], total);
 }
 
+// RMSNorm: dst[i] = x[i] / sqrt(mean(x^2) + eps).
+// only the sum-of-squares
+// reduction uses MCLNS (xlns16_add_monte).
+inline void xlns16_rms_norm_monte(const xlns16 *x, xlns16 *dst, size_t n, xlns16 eps) {
+    if (n == 0) return;
+    xlns16 sum_sq = xlns16_zero;
+    for (size_t i = 0; i < n; i++)
+        sum_sq = xlns16_add_monte(sum_sq, xlns16_square(x[i]));
+    xlns16 mean = xlns16_mul(sum_sq, fp2xlns16(1.0f / (float)n));
+    xlns16 inv_rms = xlns16_recip(xlns16_sqrt(xlns16_add(mean, eps)));
+    for (size_t i = 0; i < n; i++)
+        dst[i] = xlns16_mul(x[i], inv_rms);
+}
+
 // Layer normalization: (x - mean) / sqrt(var + eps) * gamma + beta
 inline void xlns16_layernorm_monte(const xlns16 *x, xlns16 *out,
                        const xlns16 *gamma, const xlns16 *beta,


### PR DESCRIPTION
# xlnscpp PR: Add `xlns16_rms_norm_monte`

## Summary

Add `xlns16_rms_norm_monte`, mirroring `xlns16_rms_norm`, in both Monte backends (`xlns16monte.cpp` and `xlns16monte_bylpvip.cpp`):

```
rms_norm_monte(x, eps)  = x[i] / sqrt(mean(x^2) + eps)
```

**Only the sum-of-squares reduction uses MCLNS** (`xlns16_add_monte`). Scalar `mean + eps` and elementwise ops (`square` / `mul` / `sqrt` / `recip`) use regular xlns16 ops, matching the softmax/layernorm monte convention that MCLNS applies only to vector summation.

## Motivation

Brings monte backends to parity with the xlns16 `rms_norm` control flow, parameters, and structure.

## Testing

pure monte backend:

```
fixed vector max abs diff: 0.004917
fixed vector max rel diff (|ref|>0.05): 0.4085%
dense grid (n_samples=9606, vector size 6):
  max absolute error: 0.015558
  max relative error (|ref|>0.05): 1.0143%
near-zero + eps max abs diff: 0.000000
```

bylpvip backend:

```
fixed vector max abs diff: 0.020635
fixed vector max rel diff (|ref|>0.05): 1.1428%
dense grid (n_samples=9606, vector size 6):
  max absolute error: 0.030098
  max relative error (|ref|>0.05): 1.6428%
near-zero + eps max abs diff: 0.000000
```
