### PR TITLE
Implemented RMS Norm in lpvip

### DIFF
--- a/xlns32lpvip.cpp
+++ b/xlns32lpvip.cpp
@@ -102,6 +102,20 @@ inline void xlns16_layernorm_lpvip32(const xlns16 *x, xlns16 *out,
     }
 }
 
+// RMSNorm: dst[i] = x[i] / sqrt(mean(x^2) + eps).
+// Same control flow as xlns16_rms_norm. Only the sum-of-squares reduction uses LPVIP
+// (xlns32_add_lpvip), matching layernorm variance accumulation.
+inline void xlns16_rms_norm_lpvip32(const xlns16 *x, xlns16 *dst, size_t n, xlns16 eps) {
+    if (n == 0) return;
+    xlns32 sum_sq = xlns32_zero;
+    for (size_t i = 0; i < n; i++)
+        sum_sq = xlns32_add_lpvip(sum_sq, ((xlns32)xlns16_square(x[i])) << 16);
+    xlns16 mean = xlns16_mul(sum_sq >> 16, fp2xlns16(1.0f / (float)n));
+    xlns16 inv_rms = xlns16_recip(xlns16_sqrt(xlns16_add(mean, eps)));
+    for (size_t i = 0; i < n; i++)
+        dst[i] = xlns16_mul(x[i], inv_rms);
+}
+
 // Softmax: exp(scale*a[i] - max) / sum(exp(scale*a[j] - max)).
 // Same control flow as xlns16_softmax. Scale, mask bias, and max-sub use
 // plain xlns16 ops; only the normalization sum uses xlns16_sum_lpvip32.


### PR DESCRIPTION
# xlnscpp PR: Add `xlns16_rms_norm_lpvip32`

## Summary

Add `xlns16_rms_norm_lpvip32` in `xlns32lpvip.cpp`, mirroring `xlns16_rms_norm`:

```
rms_norm_lpvip32(x, eps)  = x[i] / sqrt(mean(x^2) + eps)
```

**Only the sum-of-squares reduction uses LPVIP** (`xlns32_add_lpvip` on shifted xlns16 squares, same accumulation style as layernorm variance).

## Motivation

Brings the lpvip backend to parity with the xlns16 `rms_norm` control flow, parameters, and structure.

## Testing

```
fixed vector max abs diff: 0.020635
fixed vector max rel diff (|ref|>0.05): 1.1428%
dense grid (n_samples=9606, vector size 6):
  max absolute error: 0.027467
  max relative error (|ref|>0.05): 1.5726%
near-zero + eps max abs diff: 0.000000
```
